### PR TITLE
Fix Changelog header to reflect that API v2 is no longer in beta

### DIFF
--- a/content/v2/changelog.markdown
+++ b/content/v2/changelog.markdown
@@ -5,9 +5,9 @@ excerpt: History of the changes to the API v2.
 
 # Changelog
 
-API v2 are currently in beta, and they are in active development. As part of the beta, we may introduce some changes to the API methods, serialized responses or signatures.
+The stable version of the DNSimple API v2 was released in December 2016. API v1 was shut down permanently on May 31, 2018. 
 
-This page lists all the changes since API v2 were announced in public beta. If you use our official API clients, in most cases the changes are taken care for you.
+This page lists all the changes since API v2 was announced in public beta. If you use our official API clients, in most cases the changes are taken care for you.
 
 [Subscribe to the changes via our RSS feed.](/v2/feed.xml)
 


### PR DESCRIPTION
Found one more spot that needed to be updated…